### PR TITLE
ローカル環境での実行時にポートを固定する

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ docker-compose build --no-cache
 docker-compose run --rm codecept run -d --env default --html report.html
 ```
 
+ローカルでの確認用にポートを固定したい場合は、`docker-compose.dev.yml`も読み込んでください。(並列実行時には利用できません。)
+```
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm codecept run -d --html report.html
+```
+
 ### 並列実行
 
 `--project-name <project name> run -d` オプションで並列実行が可能です。

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ docker-compose run --rm codecept run -d --env default --html report.html
 
 ローカルでの確認用にポートを固定したい場合は、`docker-compose.dev.yml`も読み込んでください。(並列実行時には利用できません。)
 ```
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm codecept run -d --html report.html
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm codecept run -d --env default --html report.html
 ```
 
 ### 並列実行

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,8 @@
+version: "2"
+services:
+  eccube3:
+    ports:
+      - "8080:80"
+  firefox:
+    ports:
+      - "5900:5900"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,6 @@ services:
   eccube3:
     ports:
       - "8080:80"
-  firefox:
+  browser:
     ports:
       - "5900:5900"


### PR DESCRIPTION
開発時にCodeceptionの動作を確認するためにポートを確認するのが面倒なので、固定できるようにしました。