### PR TITLE
ECCUBE_REPOS/ECCUBE_BRANCHを環境変数から取得するように修正

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+ECCUBE_BRANCH=master
+ECCUBE_REPOS=https://github.com/EC-CUBE/ec-cube.git
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     build:
       context: eccube3
       args:
-        - ECCUBE_BRANCH=master
-        - ECCUBE_REPOS=https://github.com/EC-CUBE/ec-cube.git
+        - ECCUBE_BRANCH=${ECCUBE_BRANCH}
+        - ECCUBE_REPOS=${ECCUBE_REPOS}
         - DBTYPE=pgsql
     environment:
       - PGPASSWORD=password
@@ -30,8 +30,8 @@ services:
     build:
       context: codeception
       args:
-        - ECCUBE_BRANCH=master
-        - ECCUBE_REPOS=https://github.com/EC-CUBE/ec-cube.git
+        - ECCUBE_BRANCH=${ECCUBE_BRANCH}
+        - ECCUBE_REPOS=${ECCUBE_REPOS}
         - DBTYPE=pgsql
     links:
       - mailcatcher


### PR DESCRIPTION
Travis上でも環境変数を設定するだけで別リポジトリ/ブランチのEC-CUBEを対象にテストできるようになります。
デフォルト値は.envファイルに記述しています。