### PR TITLE
テストを実装できるように、acceptance/_bootstrap.phpファイルを修正。

### DIFF
--- a/tests/acceptance/_bootstrap.php
+++ b/tests/acceptance/_bootstrap.php
@@ -24,6 +24,7 @@ $entityManager = $container->get('doctrine')->getManager();
 
 use Eccube\Common\Constant;
 use Eccube\Entity\Customer;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Master\CustomerStatus;
 
 $faker = Faker::create('ja_JP');
@@ -130,7 +131,7 @@ Fixtures::add('admin_account',array(
     'password' => $config['admin_password'],
 ));
 /** $app['config'] 情報. */
-Fixtures::add('config', $container->getParameter('eccube.constants'));
+Fixtures::add('config', $container->get(EccubeConfig::class));
 
 /** config.ini 情報. */
 Fixtures::add('test_config', $config);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
・テストを実装する時に、「The parameter "eccube.constants" must be defined」というエラーが出てしまいました。
・acceptance/_bootstrap.phpファイルを修正しました。

## 実装に関する補足(Appendix)
・$container->getParameter('eccube.constants')を$container->get(EccubeConfig::class)に更新しました。
