### PR TITLE
codeception内のテストでメールを送信できるように、docker-compose.ymlを修正。

### DIFF
--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -11,6 +11,7 @@ services:
       args:
         - DBTYPE=pgsql
     environment:
+      - PGUSER=eccube_user
       - PGPASSWORD=password
       - POSTGRES_ENV_POSTGRES_PASSWORD=password
       - DATABASE_URL=pgsql://eccube_user:password@db:5432/eccube_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - ECCUBE_DB_USERNAME=eccube_user
       - ECCUBE_DB_PASSWORD=password
       - ECCUBE_DB_DATABASE=eccube_db
-      - ECCUBE_AUTH_MAGIC=XjosAXOzO1B3mE0egwQA
+      - ECCUBE_AUTH_MAGIC=secret
       - ECCUBE_MAIL_HOST=mailcatcher
       - ECCUBE_MAIL_PORT=1025
       - ECCUBE_COOKIE_NAME=eccube

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         - DBTYPE=pgsql
     environment:
       - TZ=Asia/Tokyo
-      - APP_ENV=dev
+      - APP_ENV=prod
       - APP_DEBUG=1
       - APP_SECRET=s$cretf0rt3st
       - MAILER_URL=smtp://mailcatcher:1025

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,15 +17,20 @@ services:
         - DBTYPE=pgsql
     environment:
       - TZ=Asia/Tokyo
-      - ECCUBE_DB_HOST=db
-      - ECCUBE_DB_USERNAME=eccube_user
-      - ECCUBE_DB_PASSWORD=password
-      - ECCUBE_DB_DATABASE=eccube_db
-      - ECCUBE_AUTH_MAGIC=XjosAXOzO1B3mE0egwQA
-      - ECCUBE_MAIL_HOST=mailcatcher
-      - ECCUBE_MAIL_PORT=1025
-      - ECCUBE_ADMIN_USER=admin
-      - ECCUBE_ADMIN_PASS=password
+      - APP_ENV=dev
+      - APP_DEBUG=1
+      - APP_SECRET=s$cretf0rt3st
+      - DATABASE_URL=sqlite:///%kernel.project_dir%/app/config/eccube/eccube.db
+      - DATABASE_SERVER_VERSION=3
+      - MAILER_URL=smtp://mailcatcher:1025
+      - ECCUBE_AUTH_MAGIC=secret
+      - ECCUBE_FORCE_SSL=false
+      - ECCUBE_ADMIN_ALLOW_HOSTS='["127.0.0.1"]'
+      - ECCUBE_COOKIE_LIFETIME=0
+      - ECCUBE_COOKIE_NAME=eccube
+      - ECCUBE_LOCALE=ja
+      - ECCUBE_TIMEZONE=Asia/Tokyo
+      - ECCUBE_CURRENCY=JPY
       - ECCUBE_ADMIN_ROUTE=admin
     ports:
       - 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,6 @@ services:
       - APP_ENV=dev
       - APP_DEBUG=1
       - APP_SECRET=s$cretf0rt3st
-      - DATABASE_URL=sqlite:///%kernel.project_dir%/app/config/eccube/eccube.db
-      - DATABASE_SERVER_VERSION=3
       - MAILER_URL=smtp://mailcatcher:1025
       - ECCUBE_AUTH_MAGIC=secret
       - ECCUBE_FORCE_SSL=false

--- a/eccube3/wait-for-mysql.sh
+++ b/eccube3/wait-for-mysql.sh
@@ -15,6 +15,9 @@ done
 >&2 echo "MySQL Ready"
 ${ECCUBE_PATH}/exec_env.sh
 
+bin/console cache:clear --no-warmup
+bin/console cache:warmup
+
 bin/console doctrine:schema:create
 bin/console eccube:fixtures:load
 

--- a/eccube3/wait-for-mysql.sh
+++ b/eccube3/wait-for-mysql.sh
@@ -15,11 +15,10 @@ done
 >&2 echo "MySQL Ready"
 ${ECCUBE_PATH}/exec_env.sh
 
-bin/console cache:clear --no-warmup
-bin/console cache:warmup
-
 bin/console doctrine:schema:create
 bin/console eccube:fixtures:load
+
+bin/console cache:warmup --env=prod
 
 chown -R www-data:www-data ${ECCUBE_PATH}/app
 apache2-foreground

--- a/eccube3/wait-for-pgsql.sh
+++ b/eccube3/wait-for-pgsql.sh
@@ -12,11 +12,10 @@ done
 >&2 echo "Postgres is up - executing command"
 ${ECCUBE_PATH}/exec_env.sh
 
-bin/console cache:clear --no-warmup
-bin/console cache:warmup
-
 bin/console doctrine:schema:create
 bin/console eccube:fixtures:load
+
+bin/console cache:warmup --env=prod
 
 chown -R www-data:www-data ${ECCUBE_PATH}/app
 apache2-foreground

--- a/eccube3/wait-for-pgsql.sh
+++ b/eccube3/wait-for-pgsql.sh
@@ -12,6 +12,9 @@ done
 >&2 echo "Postgres is up - executing command"
 ${ECCUBE_PATH}/exec_env.sh
 
+bin/console cache:clear --no-warmup
+bin/console cache:warmup
+
 bin/console doctrine:schema:create
 bin/console eccube:fixtures:load
 


### PR DESCRIPTION
- 環境変数として `APP_ENV=dev` を渡すことで、コンテナ内の.envファイルを読み込まないように制御。
- 必要な環境設定はdocker-compose.ymlで渡す。