### PR TITLE
Acceptance test for EA02AuthenticationCest

### DIFF
--- a/tests/acceptance/EA02AuthenticationCest.php
+++ b/tests/acceptance/EA02AuthenticationCest.php
@@ -32,7 +32,7 @@ class EA02AuthenticationCest
             'password' => "invalidpassword"
         ]);
 
-        $I->see('ログインできませんでした。', '.login-box #form1 .text-danger');
+        $I->see('資格が無効です。', '.login-box #form1 .text-danger');
     }
 
     public function authentication_最終ログイン日時確認(\AcceptanceTester $I)


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
・テストを実行できるように、EA02AuthenticationCest.phpを修正しました。
・本体スースに、「資格が無効です。」というメッセージを使用しているから、テストソースに、メッセージの内容を「ログインできませんでした。」から「資格が無効です。」に更新しました。