### PR TITLE
codeception EA06ContentsManagementCest

### DIFF
--- a/tests/acceptance/EA06ContentsManagementCest.php
+++ b/tests/acceptance/EA06ContentsManagementCest.php
@@ -105,7 +105,7 @@ class EA06ContentsManagementCest
         $I->see('folder1', $FileManagePage->パンくず(1));
 
         $config = Fixtures::get('config');
-        $I->amOnPage('/'.$config['admin_route'].'/content/file_manager');
+        $I->amOnPage('/'.$config['eccube_admin_route'].'/content/file_manager');
         $I->see('コンテンツ管理ファイル管理', '#main .page-header');
 
         FileManagePage::go($I)

--- a/tests/acceptance/EA06ContentsManagementCest.php
+++ b/tests/acceptance/EA06ContentsManagementCest.php
@@ -125,7 +125,7 @@ class EA06ContentsManagementCest
             ->入力_ファイル名('page1')
             ->入力_URL('page1')
             ->入力_内容('page1')
-            ->入力_PC用レイアウト('トップページ用レイアウト')
+            ->入力_PC用レイアウト('下層ページ用レイアウト')
             ->登録();
         $I->see('登録が完了しました。', PageEditPage::$登録完了メッセージ);
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ PullRequestの目的 : EA06ContentsManagementCest
 
## Discussion
+ contentsmanagement_ページ管理 function NG
  - Reason : in core EC-CUBE TwigInitializeListener: setFrontVaribales() maybe add 
```
/** @var \Symfony\Component\HttpFoundation\ParameterBag $reqAttributes */
        $reqAttributes = $event->getRequest()->attributes;
        $route = $reqAttributes->get('_route');
        if ($route == 'user_data') {
            $routeParams = $reqAttributes->get('_route_params', []);
            $route = isset($routeParams['route']) ? $routeParams['route'] : $reqAttributes->get('route', '');
        }
```

## テスト（Test)
+ CodeCeption local
