### PR TITLE
EA08SysteminfoCestを動作するように修正

### DIFF
--- a/tests/acceptance/EA08SysteminfoCest.php
+++ b/tests/acceptance/EA08SysteminfoCest.php
@@ -110,7 +110,7 @@ class EA08SysteminfoCest
         $I->see('メンバー登録・編集', '#main .container-fluid div:nth-child(1) .box-header .box-title');
 
         $I->click('#aside_column button');
-        $I->see('入力されていません。', '#form1 div:nth-child(1) div');
+        $I->see('空であってはなりません。', '#form1 div:nth-child(1) div');
     }
 
     public function systeminfo_メンバー管理編集実施(\AcceptanceTester $I)
@@ -178,7 +178,7 @@ class EA08SysteminfoCest
         $I->fillField(['id' => 'admin_member_name'], '');
         $I->click('#aside_column button');
 
-        $I->see('入力されていません。', '#form1 div:nth-child(1) div');
+        $I->see('空であってはなりません。', '#form1 div:nth-child(1) div');
     }
 
     public function systeminfo_メンバー管理登録下へ(\AcceptanceTester $I)


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ codeceptionのsysteminfoを動作するように修正

## テスト（Test)
CodeCeption local

## 相談（Discussion）
・それぞれのケースを実行できる。
・すべてのケースを一度に実行した時に、エラーが出るかもしれません。
　　⇒理由はセッションが失われるから、admin / loginページに遷移します。
・Eccube本体がまだ実装されていないので、以下のケースがペンディングとなります。
　　Ea0805-uc01-t01 権限管理 - 追加
　　Ea0804-uc01-t03 セキュリティ管理 - ip制限
　　Ea0806-uc01-t01　ログ表示