### PR TITLE
ショップマスター画面の管理画面UI置き換え対応

### DIFF
--- a/tests/_support/Page/Admin/ShopSettingPage.php
+++ b/tests/_support/Page/Admin/ShopSettingPage.php
@@ -4,9 +4,9 @@
 namespace Page\Admin;
 
 
-class ShopSettingPage extends AbstractAdminPage
+class ShopSettingPage extends AbstractAdminPageStyleGuide
 {
-    public static $登録完了メッセージ = '#main .container-fluid div:nth-child(1) .alert-success';
+    public static $登録完了メッセージ = '#page_admin_setting_shop > div > div.c-contentsArea > div.alert.alert-success.alert-dismissible.fade.show.m-3 > span';
 
     public function __construct(\AcceptanceTester $I)
     {
@@ -16,7 +16,7 @@ class ShopSettingPage extends AbstractAdminPage
     public static function go($I)
     {
         $page = new self($I);
-        return $page->goPage('/setting/shop', '基本情報設定ショップマスター');
+        return $page->goPage('/setting/shop', 'ショップマスター基本情報設定');
     }
 
     public function 入力_会社名($value)
@@ -27,7 +27,7 @@ class ShopSettingPage extends AbstractAdminPage
 
     public function 登録()
     {
-        $this->tester->click('#point_form #aside_column button');
+        $this->tester->click('#point_form > div.c-conversionArea > div > div > div:nth-child(2) > div > div > button');
         return $this;
     }
 }


### PR DESCRIPTION
ショップマスター画面の管理画面UI置き換えに対応したcodeceptionの修正です。
本体側：https://github.com/EC-CUBE/ec-cube/pull/2877