### PR TITLE
ページタイトルの並び順とCSSセレクタをモックに合わせて修正。

### DIFF
--- a/tests/_support/Page/Admin/AbstractAdminPageStyleGuide.php
+++ b/tests/_support/Page/Admin/AbstractAdminPageStyleGuide.php
@@ -14,7 +14,7 @@ abstract class AbstractAdminPageStyleGuide extends AbstractAdminPage
      */
     protected function atPage($pageTitle)
     {
-        $this->tester->see($pageTitle, '.c-pageTitle h2.c-pageTitle__title');
+        $this->tester->see($pageTitle, '.c-pageTitle');
         return $this;
     }
 }

--- a/tests/_support/Page/Admin/CustomerEditPage.php
+++ b/tests/_support/Page/Admin/CustomerEditPage.php
@@ -20,13 +20,13 @@ class CustomerEditPage extends AbstractAdminPageStyleGuide
     public static function go($I)
     {
         $page = new self($I);
-        return $page->goPage('/customer/new', '会員管理会員登録・編集');
+        return $page->goPage('/customer/new', '会員登録・編集会員管理');
     }
 
     public static function at($I)
     {
         $page = new self($I);
-        return $page->atPage('会員管理会員登録・編集');
+        return $page->atPage('会員登録・編集会員管理');
     }
 
     public function 入力_姓($value)

--- a/tests/_support/Page/Admin/ProductManagePage.php
+++ b/tests/_support/Page/Admin/ProductManagePage.php
@@ -30,7 +30,7 @@ class ProductManagePage extends AbstractAdminPageStyleGuide
     public static function go(\AcceptanceTester $I)
     {
         $page = new ProductManagePage($I);
-        return $page->goPage(self::$URL, '商品管理商品マスター');
+        return $page->goPage(self::$URL, '商品マスター商品管理');
     }
 
     /**
@@ -42,7 +42,7 @@ class ProductManagePage extends AbstractAdminPageStyleGuide
     {
         $this->tester->fillField(self::$検索条件_プロダクト, $product);
         $this->tester->click(self::$検索ボタン);
-        $this->tester->see('商品管理商品マスター', '.c-pageTitle h2.c-pageTitle__title');
+        $this->tester->see('商品マスター商品管理', '.c-pageTitle');
         return $this;
     }
 

--- a/tests/acceptance/EA01TopCest.php
+++ b/tests/acceptance/EA01TopCest.php
@@ -14,7 +14,7 @@ use Page\Admin\TopPage;
 class EA01TopCest
 {
     const ページタイトル = '#main .page-header';
-    const ページタイトルStyleGuide = '.c-pageTitle h2.c-pageTitle__title';
+    const ページタイトルStyleGuide = '.c-pageTitle';
 
     public function _before(\AcceptanceTester $I)
     {


### PR DESCRIPTION
ページタイトルの並び順をmocに合わせて修正しました。

https://github.com/EC-CUBE/ec-cube/pull/2897 の後に取り込みお願いします。