### PR TITLE
YAMLのエラーを修正

### DIFF
--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -87,5 +87,5 @@ env:
         modules:
             config:
                 WebDriver:
-                    http_proxy: %VADDY_PROXY%
-                    http_proxy_port: %VADDY_PROXY_PORT%
+                    http_proxy: '%VADDY_PROXY%'
+                    http_proxy_port: '%VADDY_PROXY_PORT%'


### PR DESCRIPTION
`eccube/php7-ext-codeception`のイメージが更新されてからエラーが出るようになったので修正