### PR TITLE
Fatal errorを回避

### DIFF
--- a/codeception/Dockerfile
+++ b/codeception/Dockerfile
@@ -29,7 +29,7 @@ RUN { \
     echo "APP_ENV=test"; \
     echo "APP_DEBUG=0"; \
 } > ${ECCUBE_PATH}/.env
-RUN composer install
+RUN composer install && rm -rf ${ECCUBE_PATH}/var/cache
 
 ## create config yaml files
 WORKDIR /project


### PR DESCRIPTION
[container.dumper.inline_class_loaderを有効に](https://github.com/EC-CUBE/ec-cube/commit/cdb8d56dbd68652e0b64932614a3d7a04b6af89c) したときにCodeceptionからKernelを起動するとエラーになっていたので、キャッシュを削除しておくことで回避。