### PR TITLE
商品規格設定画面のUI変更対応

### DIFF
--- a/tests/_support/Page/Admin/ClassCategoryManagePage.php
+++ b/tests/_support/Page/Admin/ClassCategoryManagePage.php
@@ -5,7 +5,7 @@ namespace Page\Admin;
 use Facebook\WebDriver\Interactions\WebDriverActions;
 use Facebook\WebDriver\WebDriverBy;
 
-class ProductClassCategoryPage extends AbstractAdminPageStyleGuide
+class ClassCategoryManagePage extends AbstractAdminPageStyleGuide
 {
 
     public static $登録完了メッセージ = ['css' => '#page_admin_product_class_category > div > div.c-contentsArea > div.alert'];
@@ -22,7 +22,7 @@ class ProductClassCategoryPage extends AbstractAdminPageStyleGuide
 
     public static function at($I)
     {
-        $page = new ProductClassCategoryPage($I);
+        $page = new ClassCategoryManagePage($I);
         return $page->atPage('規格管理商品管理');;
     }
 

--- a/tests/_support/Page/Admin/ClassNameManagePage.php
+++ b/tests/_support/Page/Admin/ClassNameManagePage.php
@@ -9,7 +9,7 @@ use Interactions\DragAndDropBy;
  * 商品管理規格編集
  * @package Page\Admin
  */
-class ProductClassPage extends AbstractAdminPageStyleGuide
+class ClassNameManagePage extends AbstractAdminPageStyleGuide
 {
 
     public static $登録完了メッセージ = ['css' => '#page_admin_product_class_name > div > div.c-contentsArea > div.alert'];
@@ -25,7 +25,7 @@ class ProductClassPage extends AbstractAdminPageStyleGuide
 
     public static function go($I)
     {
-        $page = new ProductClassPage($I);
+        $page = new ClassNameManagePage($I);
         return $page->goPage('/product/class_name', '規格管理商品管理');
     }
 

--- a/tests/_support/Page/Admin/ProductClassEditPage.php
+++ b/tests/_support/Page/Admin/ProductClassEditPage.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2018 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Page\Admin;
+
+
+class ProductClassEditPage extends AbstractAdminPageStyleGuide
+{
+    public static $登録完了メッセージ = ['css' => '#page_admin_product_product_class > div > div.c-contentsArea > div.alert.alert-success.alert-dismissible.fade.show.m-3'];
+
+    public static $初期化ボタン = ['css' => '#form > div.c-contentsArea__cols > div > div > div:nth-child(1) > div.card-header > div > div.col-4.text-right > button'];
+
+    /**
+     * ProductReProductClassEditPagegisterPage constructor.
+     */
+    public function __construct(\AcceptanceTester $I)
+    {
+        parent::__construct($I);
+    }
+
+    public static function at($I)
+    {
+        $page = new ProductClassEditPage($I);
+        $page->atPage('商品登録（規格設定）商品管理');
+        return $page;
+    }
+
+    public function 規格設定()
+    {
+        $this->tester->click(['css' => '#form > div.c-contentsArea__cols > div > div > div > div.card-header > div > div.col-4.text-right > button']);
+        return $this;
+    }
+
+    public function 入力_規格1($value)
+    {
+        $this->tester->selectOption(['id' => 'form_class_name1'], $value);
+        return $this;
+    }
+
+    public function 選択($rowNum)
+    {
+        $rowNum -= 1;
+        $this->tester->checkOption(['id' => "form_product_classes_${rowNum}_add"]);
+        return $this;
+    }
+
+    public function 規格初期化()
+    {
+        $this->tester->click(self::$初期化ボタン);
+        $this->tester->waitForElement(['css' => '#initializationConfirm > div > div > div.modal-footer > button.btn.btn-ec-delete']);
+        $this->tester->wait(1);
+        $this->tester->click(['css' => '#initializationConfirm > div > div > div.modal-footer > button.btn.btn-ec-delete']);
+        return $this;
+    }
+
+    public function 登録()
+    {
+        $this->tester->click(['css' => '#form > div.c-conversionArea > div > div > div:nth-child(2) > div > div > button']);
+        return $this;
+    }
+}

--- a/tests/_support/Page/Admin/ProductEditPage.php
+++ b/tests/_support/Page/Admin/ProductEditPage.php
@@ -55,9 +55,19 @@ class ProductEditPage extends AbstractAdminPageStyleGuide
         return $this;
     }
 
+    public function 規格管理()
+    {
+        $this->tester->click(['css' => '#standardConfig > div > div.d-block.text-center.text-center > button']);
+        $this->tester->waitForElement(['css' => '#confirmModal > div > div > div.modal-footer > a']);
+        $this->tester->wait(1);
+        $this->tester->click(['css' => '#confirmModal > div > div > div.modal-footer > a']);
+        return $this;
+    }
+
     public function 登録()
     {
         $this->tester->click('#form1 > div.c-conversionArea > div > div > div:nth-child(2) > div > div:nth-child(2) > button');
         return $this;
     }
+
 }

--- a/tests/_support/Page/Admin/ProductManagePage.php
+++ b/tests/_support/Page/Admin/ProductManagePage.php
@@ -53,8 +53,6 @@ class ProductManagePage extends AbstractAdminPageStyleGuide
      */
     public function 検索結果_規格設定($rowNum)
     {
-        $this->tester->getScenario()->incomplete('未実装：商品マスター画面での規格一覧の閲覧は未実装');
-
         $this->tester->click("#main #result_list__list > div > div:nth-child(${rowNum}) > div:nth-child(4) > div > ul > li:nth-child(1) > a");
     }
 


### PR DESCRIPTION
- https://github.com/EC-CUBE/ec-cube/pull/2939 の対応
- 以下のPageクラスのクラス名を変更
    - 規格管理画面 `ProductClassPage` -> `ClassNameManagePage`
    - 規格分類管理画面 `ProductClassCategoryPage` -> `ClassCategoryManagePage`
- テスト結果
    - https://travis-ci.org/kiy0taka/eccube-codeception/builds/352728975