### PR TITLE
規格確認のモーダルが閉じるのを待つコードを追加

### DIFF
--- a/tests/_support/Page/Admin/OrderManagePage.php
+++ b/tests/_support/Page/Admin/OrderManagePage.php
@@ -60,6 +60,7 @@ class OrderManagePage extends AbstractAdminPageStyleGuide
 
     public function Accept_削除()
     {
+        $this->tester->waitForElementVisible(['id' => 'btn_bulk_delete']);
         $this->tester->click("#btn_bulk_delete");
         return $this;
     }

--- a/tests/_support/Page/Admin/ProductManagePage.php
+++ b/tests/_support/Page/Admin/ProductManagePage.php
@@ -109,6 +109,7 @@ class ProductManagePage extends AbstractAdminPageStyleGuide
     {
         $this->tester->click("#page_admin_product > div > div.c-contentsArea > div.c-contentsArea__cols > div > div > form > div.card.rounded.border-0.mb-4 > div.card-body.p-0 > table > tbody > tr > td:nth-child(7) > button.page-link");
         $this->tester->waitForElementVisible(['id' => 'productClassesModal']);
+        $this->tester->wait(1);
         return $this;
     }
 

--- a/tests/_support/Page/Admin/ProductManagePage.php
+++ b/tests/_support/Page/Admin/ProductManagePage.php
@@ -119,6 +119,7 @@ class ProductManagePage extends AbstractAdminPageStyleGuide
     public function 規格確認をキャンセル()
     {
         $this->tester->click("#page_admin_product div#productClassesModal .modal-footer button.btn-v-sub");
+        $this->tester->waitForElementNotVisible(['id' => 'productClassesModal']);
         return $this;
     }
 


### PR DESCRIPTION
モーダルを閉じたかどうかの検証が、タイミングによってNGのになるのを防ぐコードを追加。
モーダルが非表示になってから、次のステップに進むようにした。

see https://travis-ci.org/EC-CUBE/eccube-codeception/jobs/363719287#L2731