### PR TITLE
未使用ブロック検索のテストケースで利用するブロック名を変更

### DIFF
--- a/tests/acceptance/EA06ContentsManagementCest.php
+++ b/tests/acceptance/EA06ContentsManagementCest.php
@@ -201,7 +201,7 @@ class EA06ContentsManagementCest
         LayoutManagePage::go($I)->レイアウト編集($layoutName);
         $items = $I->grabMultiple(LayoutEditPage::$未使用ブロックアイテム);
         LayoutEditPage::at($I)
-            ->検索ブロック名('カゴの中');
+            ->検索ブロック名('ギャラリー');
 
         $I->seeNumberOfElements(LayoutEditPage::$未使用ブロックアイテム, 1);
 


### PR DESCRIPTION
他のテストで「カゴの中」を未使用ブロックから移動している。
このテストケースでは未使用ブロックを検索したいので、検索するブロックを変更した。